### PR TITLE
fix #45: comment 버튼 클릭 시 게시글 링크와 코멘트 링크 둘 다 열리는 문제 해결

### DIFF
--- a/src/components/body/list/ArticleItem.tsx
+++ b/src/components/body/list/ArticleItem.tsx
@@ -1,3 +1,4 @@
+import { MouseEvent } from 'react';
 import styled from 'styled-components';
 import { IArticleItem } from '../../../config/types/componentTypes';
 import {
@@ -18,8 +19,9 @@ export const ArticleItem = ({
     window.open(link, '_blank');
   };
 
-  const handleClickPrBtn = () => {
+  const handleClickPrBtn = (e: MouseEvent) => {
     window.open(prLink, '_blank');
+    e.stopPropagation();
   };
 
   return (


### PR DESCRIPTION
간단하게 이벤트 전파를 막아서 해결했습니다~